### PR TITLE
Add `Unitary` and `TensorProduct` block encodings

### DIFF
--- a/dev_tools/autogenerate-bloqs-notebooks-v2.py
+++ b/dev_tools/autogenerate-bloqs-notebooks-v2.py
@@ -570,6 +570,8 @@ OTHER: List[NotebookSpecV2] = [
             qualtran.bloqs.block_encoding.lcu_block_encoding._LCU_BLOCK_ENCODING_DOC,
             qualtran.bloqs.block_encoding.lcu_block_encoding._LCU_ZERO_STATE_BLOCK_ENCODING_DOC,
             qualtran.bloqs.block_encoding.chebyshev_polynomial._CHEBYSHEV_BLOQ_DOC,
+            qualtran.bloqs.block_encoding.unitary._UNITARY_DOC,
+            qualtran.bloqs.block_encoding.tensor_product._TENSOR_PRODUCT_DOC,
         ],
         directory=f'{SOURCE_DIR}/bloqs/block_encoding/',
     ),

--- a/dev_tools/autogenerate-bloqs-notebooks-v2.py
+++ b/dev_tools/autogenerate-bloqs-notebooks-v2.py
@@ -192,6 +192,7 @@ BASIC_GATES: List[NotebookSpecV2] = [
             qualtran.bloqs.bookkeeping.split._SPLIT_DOC,
             qualtran.bloqs.bookkeeping.join._JOIN_DOC,
             qualtran.bloqs.bookkeeping.partition._PARTITION_DOC,
+            qualtran.bloqs.bookkeeping.auto_partition._AUTO_PARTITION_DOC,
             qualtran.bloqs.bookkeeping.cast._CAST_DOC,
         ],
     ),

--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -966,6 +966,35 @@ class BloqBuilder:
         binst = BloqInstance(bloq, i=self._new_binst_i())
         return dict(self._add_binst(binst, in_soqs=in_soqs))
 
+    def add_and_partition(
+        self,
+        bloq: Bloq,
+        partitions: Sequence[Tuple[Register, Sequence[str]]],
+        left_only: bool = False,
+        **in_soqs: SoquetInT,
+    ):
+        """Add a new bloq instance to the compute graph by partitioning input and output soquets to
+        fit the signature of the bloq.
+
+        Args:
+            bloq: The bloq representing the operation to add.
+            partitions: A sequence of pairs specifying each register that the wrapped bloq should
+            accept and the register names from `bloq.signature.lefts()` that concatenate to form it.
+            left_only: If False, the output soquets will also follow `partition`.
+                Otherwise, the output soquets will follow `bloq.signature.rights()`.
+                This flag must be set to True if `bloq` does not have the same LEFT and RIGHT registers,
+                as is required for the bloq to be fully wrapped on the left and right.
+            **in_soqs: Keyword arguments mapping the new bloq's register names to input
+                `Soquet`s. This is likely the output soquets from a prior operation.
+
+        Returns:
+            A `Soquet` or an array thereof for each right (output) register ordered according to
+                `bloq.signature` or `partition`.
+        """
+        from qualtran.bloqs.bookkeeping.auto_partition import AutoPartition
+
+        return self.add(AutoPartition(bloq, partitions, left_only), **in_soqs)
+
     def add(self, bloq: Bloq, **in_soqs: SoquetInT):
         """Add a new bloq instance to the compute graph.
 

--- a/qualtran/_infra/composite_bloq_test.py
+++ b/qualtran/_infra/composite_bloq_test.py
@@ -556,6 +556,24 @@ def test_t_complexity():
     assert TestParallelCombo().t_complexity().t == 3 * 100
 
 
+def test_add_and_partition():
+    from qualtran import Controlled, CtrlSpec
+    from qualtran.bloqs.basic_gates import Swap
+
+    bb = BloqBuilder()
+    bloq = Controlled(Swap(3), CtrlSpec(qdtypes=QUInt(4), cvs=0b0110))
+    a = bb.add_register_from_dtype('a', QAny(7))
+    b = bb.add_register_from_dtype('b', QAny(3))
+    assert a is not None
+    assert b is not None
+    a, b = bb.add_and_partition(
+        bloq, [(Register('a', QAny(7)), ['y', 'ctrl']), (Register('b', QAny(3)), ['x'])], a=a, b=b
+    )
+    cbloq = bb.finalize(a=a, b=b)
+    assert isinstance(cbloq, CompositeBloq)
+    assert len(cbloq.bloq_instances) == 1
+
+
 @pytest.mark.notebook
 def test_notebook():
     qlt_testing.execute_notebook('composite_bloq')

--- a/qualtran/_infra/registers.py
+++ b/qualtran/_infra/registers.py
@@ -162,7 +162,7 @@ class Signature:
             registers: keyword arguments mapping register name to QDType. All registers
                 will be 0-dimensional and THRU.
         """
-        return cls(Register(name=k, dtype=v) for k, v in registers.items() if v.num_qubits)
+        return cls(Register(name=k, dtype=v) for k, v in registers.items())
 
     def lefts(self) -> Iterable[Register]:
         """Iterable over all registers that appear on the LEFT as input."""

--- a/qualtran/_infra/registers_test.py
+++ b/qualtran/_infra/registers_test.py
@@ -130,7 +130,7 @@ def test_signature_build():
     sig1 = Signature([Register("r1", QInt(7)), Register("r2", QBit())])
     sig2 = Signature.build_from_dtypes(r1=QInt(7), r2=QBit())
     assert sig1 == sig2
-    sig1 = Signature([Register("r1", QInt(7))])
+    sig1 = Signature([Register("r1", QInt(7)), Register("r2", QAny(0))])
     sig2 = Signature.build_from_dtypes(r1=QInt(7), r2=QAny(0))
     assert sig1 == sig2
 

--- a/qualtran/bloqs/block_encoding/__init__.py
+++ b/qualtran/bloqs/block_encoding/__init__.py
@@ -21,3 +21,5 @@ from qualtran.bloqs.block_encoding.lcu_block_encoding import (
     LCUBlockEncoding,
     LCUBlockEncodingZeroState,
 )
+from qualtran.bloqs.block_encoding.tensor_product import TensorProduct
+from qualtran.bloqs.block_encoding.unitary import Unitary

--- a/qualtran/bloqs/block_encoding/block_encoding.ipynb
+++ b/qualtran/bloqs/block_encoding/block_encoding.ipynb
@@ -594,6 +594,238 @@
     "show_call_graph(chebyshev_poly_g)\n",
     "show_counts_sigma(chebyshev_poly_sigma)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6836a23d",
+   "metadata": {
+    "cq.autogen": "Unitary.bloq_doc.md"
+   },
+   "source": [
+    "## `Unitary`\n",
+    "Trivial block encoding of a unitary operator.\n",
+    "\n",
+    "Builds the block encoding as\n",
+    "$\n",
+    "    B[U] = U\n",
+    "$\n",
+    "where $U$ is a unitary operator. Here, $B[U]$ is a $(1, 0, 0)$-block encoding of $U$.\n",
+    "\n",
+    "#### Parameters\n",
+    " - `U`: The unitary operator to block-encode.\n",
+    " - `dtype`: The quantum data type of the system `U` operates over. \n",
+    "\n",
+    "#### Registers\n",
+    " - `system`: The system register.\n",
+    " - `ancilla`: The ancilla register (size 0).\n",
+    " - `resource`: The resource register (size 0).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10bda229",
+   "metadata": {
+    "cq.autogen": "Unitary.bloq_doc.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.block_encoding import Unitary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da23b898",
+   "metadata": {
+    "cq.autogen": "Unitary.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63966178",
+   "metadata": {
+    "cq.autogen": "Unitary.unitary_block_encoding"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran import QBit\n",
+    "from qualtran.bloqs.basic_gates import TGate\n",
+    "\n",
+    "unitary_block_encoding = Unitary(TGate(), dtype=QBit())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "670e3692",
+   "metadata": {
+    "cq.autogen": "Unitary.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97b4f383",
+   "metadata": {
+    "cq.autogen": "Unitary.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([unitary_block_encoding],\n",
+    "           ['`unitary_block_encoding`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91e9171c",
+   "metadata": {
+    "cq.autogen": "Unitary.call_graph.md"
+   },
+   "source": [
+    "### Call Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0042bd79",
+   "metadata": {
+    "cq.autogen": "Unitary.call_graph.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.resource_counting.generalizers import ignore_split_join\n",
+    "unitary_block_encoding_g, unitary_block_encoding_sigma = unitary_block_encoding.call_graph(max_depth=1, generalizer=ignore_split_join)\n",
+    "show_call_graph(unitary_block_encoding_g)\n",
+    "show_counts_sigma(unitary_block_encoding_sigma)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "278a14ac",
+   "metadata": {
+    "cq.autogen": "TensorProduct.bloq_doc.md"
+   },
+   "source": [
+    "## `TensorProduct`\n",
+    "Tensor product of a sequence of block encodings.\n",
+    "\n",
+    "Builds the block encoding as\n",
+    "$$\n",
+    "    B[U_1 ⊗ U_2 ⊗ \\cdots ⊗ U_n] = B[U_1] ⊗ B[U_2] ⊗ \\cdots ⊗ B[U_n]\n",
+    "$$\n",
+    "\n",
+    "When each $B[U_i]$ is a $(\\alpha_i, a_i, \\epsilon_i)$-block encoding of $U_i$, we have that\n",
+    "$B[U_1 ⊗ \\cdots ⊗ U_n]$ is a $(\\prod_i \\alpha_i, \\sum_i a_i, \\sum_i \\alpha_i \\epsilon_i)$-block\n",
+    "encoding of $U_1 ⊗ \\cdots ⊗ U_n$.\n",
+    "\n",
+    "#### Parameters\n",
+    " - `U`: A sequence of block encodings. \n",
+    "\n",
+    "#### Registers\n",
+    " - `system`: The system register.\n",
+    " - `ancilla`: The ancilla register.\n",
+    " - `resource`: The resource register. \n",
+    "\n",
+    "#### References\n",
+    " - [Quantum algorithms: A survey of applications and end-to-end complexities](https://arxiv.org/abs/2310.03011). Dalzell et al. (2023). Ch. 10.2.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f1e952b",
+   "metadata": {
+    "cq.autogen": "TensorProduct.bloq_doc.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.block_encoding import TensorProduct"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "004fde81",
+   "metadata": {
+    "cq.autogen": "TensorProduct.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1478a7ac",
+   "metadata": {
+    "cq.autogen": "TensorProduct.tensor_product_block_encoding"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran import QBit\n",
+    "from qualtran.bloqs.basic_gates import Hadamard, TGate\n",
+    "from qualtran.bloqs.block_encoding.unitary import Unitary\n",
+    "\n",
+    "tensor_product_block_encoding = TensorProduct(\n",
+    "    [Unitary(TGate(), dtype=QBit()), Unitary(Hadamard(), dtype=QBit())]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "611fefc9",
+   "metadata": {
+    "cq.autogen": "TensorProduct.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f34e93d7",
+   "metadata": {
+    "cq.autogen": "TensorProduct.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([tensor_product_block_encoding],\n",
+    "           ['`tensor_product_block_encoding`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53df4024",
+   "metadata": {
+    "cq.autogen": "TensorProduct.call_graph.md"
+   },
+   "source": [
+    "### Call Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0883c9f0",
+   "metadata": {
+    "cq.autogen": "TensorProduct.call_graph.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.resource_counting.generalizers import ignore_split_join\n",
+    "tensor_product_block_encoding_g, tensor_product_block_encoding_sigma = tensor_product_block_encoding.call_graph(max_depth=1, generalizer=ignore_split_join)\n",
+    "show_call_graph(tensor_product_block_encoding_g)\n",
+    "show_counts_sigma(tensor_product_block_encoding_sigma)"
+   ]
   }
  ],
  "metadata": {

--- a/qualtran/bloqs/block_encoding/block_encoding_base.py
+++ b/qualtran/bloqs/block_encoding/block_encoding_base.py
@@ -14,8 +14,9 @@
 import abc
 from typing import Tuple
 
-from qualtran import Bloq, BloqDocSpec, Register
+from qualtran import Bloq, BloqDocSpec, QDType, Register
 from qualtran.bloqs.block_encoding.lcu_select_and_prepare import PrepareOracle
+from qualtran.symbolics import SymbolicFloat
 
 
 class BlockEncoding(Bloq):
@@ -66,6 +67,31 @@ class BlockEncoding(Bloq):
 
     def pretty_name(self) -> str:
         return 'B[H]'
+
+    @property
+    def dtype(self) -> QDType:
+        """The type of the system being block encoded."""
+        raise NotImplementedError
+
+    @property
+    def alpha(self) -> SymbolicFloat:
+        """The normalization constant."""
+        raise NotImplementedError
+
+    @property
+    def num_ancillas(self) -> int:
+        """The number of ancilla qubits."""
+        raise NotImplementedError
+
+    @property
+    def num_resource(self) -> int:
+        """The number of resource qubits not counted in ancillas."""
+        raise NotImplementedError
+
+    @property
+    def epsilon(self) -> SymbolicFloat:
+        """The precision to which the block encoding is to be prepared."""
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod

--- a/qualtran/bloqs/block_encoding/tensor_product.py
+++ b/qualtran/bloqs/block_encoding/tensor_product.py
@@ -1,0 +1,152 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from functools import cached_property, reduce
+from typing import Dict, Sequence, Tuple
+
+from attrs import evolve, field, frozen
+
+from qualtran import (
+    bloq_example,
+    BloqBuilder,
+    BloqDocSpec,
+    QAny,
+    QDType,
+    Register,
+    Signature,
+    SoquetT,
+)
+from qualtran.bloqs.block_encoding import BlockEncoding
+from qualtran.bloqs.block_encoding.lcu_select_and_prepare import PrepareOracle
+from qualtran.bloqs.bookkeeping import Partition
+from qualtran.symbolics import SymbolicFloat
+
+
+@frozen
+class TensorProduct(BlockEncoding):
+    r"""Tensor product of a sequence of block encodings.
+
+    Builds the block encoding as
+    $$
+        B[U_1 ⊗ U_2 ⊗ \cdots ⊗ U_n] = B[U_1] ⊗ B[U_2] ⊗ \cdots ⊗ B[U_n]
+    $$
+
+    When each $B[U_i]$ is a $(\alpha_i, a_i, \epsilon_i)$-block encoding of $U_i$, we have that
+    $B[U_1 ⊗ \cdots ⊗ U_n]$ is a $(\prod_i \alpha_i, \sum_i a_i, \sum_i \alpha_i \epsilon_i)$-block
+    encoding of $U_1 ⊗ \cdots ⊗ U_n$.
+
+    Args:
+        U: A sequence of block encodings.
+
+    Registers:
+        system: The system register.
+        ancilla: The ancilla register.
+        resource: The resource register.
+
+    References:
+        [Quantum algorithms: A survey of applications and end-to-end complexities](https://arxiv.org/abs/2310.03011). Dalzell et al. (2023). Ch. 10.2.
+    """
+
+    U: Sequence[BlockEncoding] = field(converter=lambda x: x if isinstance(x, tuple) else tuple(x))
+
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature.build_from_dtypes(
+            system=self.dtype, ancilla=QAny(self.num_ancillas), resource=QAny(self.num_resource)
+        )
+
+    @cached_property
+    def dtype(self) -> QDType:
+        return QAny(bitsize=sum(u.dtype.num_qubits for u in self.U))
+
+    def pretty_name(self) -> str:
+        return f"B[{'⊗'.join(u.pretty_name()[2:-1] for u in self.U)}]"
+
+    @cached_property
+    def alpha(self) -> SymbolicFloat:
+        return reduce(lambda a, b: a * b.alpha, self.U, 1.0)
+
+    @cached_property
+    def num_ancillas(self) -> int:
+        return sum(u.num_ancillas for u in self.U)
+
+    @cached_property
+    def num_resource(self) -> int:
+        return sum(u.num_resource for u in self.U)
+
+    @cached_property
+    def epsilon(self) -> SymbolicFloat:
+        return sum(u.alpha * u.epsilon for u in self.U)
+
+    @property
+    def target_registers(self) -> Tuple[Register, ...]:
+        return (self.signature.get_right("system"),)
+
+    @property
+    def junk_registers(self) -> Tuple[Register, ...]:
+        return (self.signature.get_right("resource"),)
+
+    @property
+    def selection_registers(self) -> Tuple[Register, ...]:
+        return (self.signature.get_right("ancilla"),)
+
+    @property
+    def signal_state(self) -> PrepareOracle:
+        raise NotImplementedError
+
+    def build_composite_bloq(
+        self, bb: BloqBuilder, system: SoquetT, ancilla: SoquetT, resource: SoquetT
+    ) -> Dict[str, SoquetT]:
+        transpose = lambda x: zip(*x)
+        sys_regs, anc_regs, res_regs = transpose(
+            [evolve(r, name=f"{r.name}{i}") for r in u.signature.lefts()]
+            for i, u in enumerate(self.U)
+        )
+        sys_part = Partition(self.dtype.num_qubits, regs=sys_regs)
+        anc_part = Partition(self.num_ancillas, regs=anc_regs)
+        res_part = Partition(self.num_resource, regs=res_regs)
+        sys_out_regs = list(bb.add_t(sys_part, x=system))
+        anc_out_regs = list(bb.add_t(anc_part, x=ancilla))
+        res_out_regs = list(bb.add_t(res_part, x=resource))
+        for i, u in enumerate(self.U):
+            sys_out_regs[i], anc_out_regs[i], res_out_regs[i] = bb.add_t(
+                u, system=sys_out_regs[i], ancilla=anc_out_regs[i], resource=res_out_regs[i]
+            )
+        system = bb.add(sys_part.adjoint(), **{r.name: sp for r, sp in zip(sys_regs, sys_out_regs)})
+        ancilla = bb.add(
+            anc_part.adjoint(), **{r.name: ap for r, ap in zip(anc_regs, anc_out_regs)}
+        )
+        resource = bb.add(
+            res_part.adjoint(), **{r.name: ap for r, ap in zip(res_regs, res_out_regs)}
+        )
+        return {"system": system, "ancilla": ancilla, "resource": resource}
+
+
+@bloq_example
+def _tensor_product_block_encoding() -> TensorProduct:
+    from qualtran import QBit
+    from qualtran.bloqs.basic_gates import Hadamard, TGate
+    from qualtran.bloqs.block_encoding.unitary import Unitary
+
+    tensor_product_block_encoding = TensorProduct(
+        [Unitary(TGate(), dtype=QBit()), Unitary(Hadamard(), dtype=QBit())]
+    )
+    return tensor_product_block_encoding
+
+
+_TENSOR_PRODUCT_DOC = BloqDocSpec(
+    bloq_cls=TensorProduct,
+    import_line="from qualtran.bloqs.block_encoding import TensorProduct",
+    examples=[_tensor_product_block_encoding],
+)

--- a/qualtran/bloqs/block_encoding/tensor_product_test.py
+++ b/qualtran/bloqs/block_encoding/tensor_product_test.py
@@ -1,0 +1,55 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import numpy as np
+from attrs import evolve
+
+from qualtran import QAny, QBit, Register, Signature
+from qualtran.bloqs.basic_gates import CNOT, Hadamard, TGate
+from qualtran.bloqs.block_encoding.tensor_product import (
+    _tensor_product_block_encoding,
+    TensorProduct,
+)
+from qualtran.bloqs.block_encoding.unitary import Unitary
+
+
+def test_tensor_product(bloq_autotester):
+    bloq_autotester(_tensor_product_block_encoding)
+
+
+def test_tensor_product_signature():
+    assert _tensor_product_block_encoding().signature == Signature(
+        [Register("system", QAny(2)), Register("ancilla", QAny(0)), Register("resource", QAny(0))]
+    )
+
+
+def test_tensor_product_params():
+    u1 = evolve(
+        Unitary(TGate(), dtype=QBit()), alpha=0.5, num_ancillas=2, num_resource=1, epsilon=0.01
+    )
+    u2 = evolve(
+        Unitary(CNOT(), dtype=QAny(2)), alpha=0.5, num_ancillas=1, num_resource=1, epsilon=0.1
+    )
+    bloq = TensorProduct([u1, u2])
+    assert bloq.dtype == QAny(1 + 2)
+    assert bloq.alpha == 0.5 * 0.5
+    assert bloq.epsilon == 0.5 * 0.01 + 0.5 * 0.1
+    assert bloq.num_ancillas == 2 + 1
+    assert bloq.num_resource == 1 + 1
+
+
+def test_tensor_product_tensors():
+    from_gate = np.kron(TGate().tensor_contract(), Hadamard().tensor_contract())
+    from_tensors = _tensor_product_block_encoding().tensor_contract()
+    np.testing.assert_allclose(from_gate, from_tensors)

--- a/qualtran/bloqs/block_encoding/unitary.py
+++ b/qualtran/bloqs/block_encoding/unitary.py
@@ -1,0 +1,111 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from functools import cached_property
+from typing import Dict, Tuple
+
+from attrs import frozen
+
+from qualtran import (
+    Bloq,
+    bloq_example,
+    BloqBuilder,
+    BloqDocSpec,
+    QAny,
+    QDType,
+    Register,
+    Signature,
+    SoquetT,
+)
+from qualtran.bloqs.block_encoding import BlockEncoding
+from qualtran.bloqs.block_encoding.lcu_select_and_prepare import PrepareOracle
+from qualtran.symbolics import SymbolicFloat
+
+
+@frozen
+class Unitary(BlockEncoding):
+    r"""Trivial block encoding of a unitary operator.
+
+    Builds the block encoding as
+    $
+        B[U] = U
+    $
+    where $U$ is a unitary operator. Here, $B[U]$ is a $(1, 0, 0)$-block encoding of $U$.
+
+    Args:
+        U: The unitary operator to block-encode.
+        dtype: The quantum data type of the system `U` operates over.
+
+    Registers:
+        system: The system register.
+        ancilla: The ancilla register (size 0).
+        resource: The resource register (size 0).
+    """
+
+    U: Bloq
+    dtype: QDType
+    alpha: SymbolicFloat = 1
+    num_ancillas: int = 0
+    num_resource: int = 0
+    epsilon: SymbolicFloat = 0
+
+    def __attrs_post_init__(self):
+        assert self.U.signature == self.U.signature.adjoint()
+        assert self.dtype.num_qubits == sum(r.bitsize for r in self.U.signature.rights())
+
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature.build_from_dtypes(system=self.dtype, ancilla=QAny(0), resource=QAny(0))
+
+    def pretty_name(self) -> str:
+        return f"B[{self.U.pretty_name()}]"
+
+    @property
+    def target_registers(self) -> Tuple[Register, ...]:
+        return tuple(self.signature.rights())
+
+    junk_registers: Tuple[Register, ...] = ()
+    selection_registers: Tuple[Register, ...] = ()
+
+    @property
+    def signal_state(self) -> PrepareOracle:
+        raise NotImplementedError
+
+    def build_composite_bloq(
+        self, bb: BloqBuilder, system: SoquetT, ancilla: SoquetT, resource: SoquetT
+    ) -> Dict[str, SoquetT]:
+        partitions = [
+            (self.signature.get_left("system"), tuple(r.name for r in self.U.signature.lefts()))
+        ]
+        return {
+            "system": bb.add_and_partition(self.U, partitions=partitions, system=system),
+            "ancilla": ancilla,
+            "resource": resource,
+        }
+
+
+@bloq_example
+def _unitary_block_encoding() -> Unitary:
+    from qualtran import QBit
+    from qualtran.bloqs.basic_gates import TGate
+
+    unitary_block_encoding = Unitary(TGate(), dtype=QBit())
+    return unitary_block_encoding
+
+
+_UNITARY_DOC = BloqDocSpec(
+    bloq_cls=Unitary,
+    import_line="from qualtran.bloqs.block_encoding import Unitary",
+    examples=[_unitary_block_encoding],
+)

--- a/qualtran/bloqs/block_encoding/unitary_test.py
+++ b/qualtran/bloqs/block_encoding/unitary_test.py
@@ -1,0 +1,48 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import numpy as np
+import pytest
+
+from qualtran import QAny, QBit, Register, Signature
+from qualtran.bloqs.basic_gates import IntState, TGate
+from qualtran.bloqs.block_encoding.unitary import _unitary_block_encoding, Unitary
+
+
+def test_unitary(bloq_autotester):
+    bloq_autotester(_unitary_block_encoding)
+
+
+def test_unitary_signature():
+    assert _unitary_block_encoding().signature == Signature(
+        [Register("system", QBit()), Register("ancilla", QAny(0)), Register("resource", QAny(0))]
+    )
+    with pytest.raises(AssertionError):
+        _ = Unitary(TGate(), dtype=QAny(2))
+    with pytest.raises(AssertionError):
+        _ = Unitary(IntState(55, bitsize=8), dtype=QAny(8))
+
+
+def test_unitary_params():
+    bloq = _unitary_block_encoding()
+    assert bloq.alpha == 1
+    assert bloq.epsilon == 0
+    assert bloq.num_ancillas == 0
+    assert bloq.num_resource == 0
+
+
+def test_unitary_tensors():
+    from_gate = TGate().tensor_contract()
+    from_tensors = _unitary_block_encoding().tensor_contract()
+    np.testing.assert_allclose(from_gate, from_tensors)

--- a/qualtran/bloqs/bookkeeping/__init__.py
+++ b/qualtran/bloqs/bookkeeping/__init__.py
@@ -15,6 +15,7 @@
 
 from qualtran.bloqs.bookkeeping.allocate import Allocate
 from qualtran.bloqs.bookkeeping.arbitrary_clifford import ArbitraryClifford
+from qualtran.bloqs.bookkeeping.auto_partition import AutoPartition
 from qualtran.bloqs.bookkeeping.cast import Cast
 from qualtran.bloqs.bookkeeping.free import Free
 from qualtran.bloqs.bookkeeping.join import Join

--- a/qualtran/bloqs/bookkeeping/auto_partition.py
+++ b/qualtran/bloqs/bookkeeping/auto_partition.py
@@ -1,0 +1,116 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from functools import cached_property
+from itertools import chain
+from typing import Dict, Sequence, Tuple
+
+from attrs import evolve, field, frozen
+
+from qualtran import (
+    Bloq,
+    bloq_example,
+    BloqBuilder,
+    BloqDocSpec,
+    QAny,
+    Register,
+    Side,
+    Signature,
+    SoquetT,
+)
+from qualtran.bloqs.bookkeeping.partition import Partition
+
+
+@frozen
+class AutoPartition(Bloq):
+    """Wrap a bloq with `Partition` to fit an alternative set of input and output registers
+       such that splits / joins can be avoided in diagrams.
+
+    Args:
+        bloq: The bloq to wrap.
+        partitions: A sequence of pairs specifying each register that the wrapped bloq should accept
+            and the names of registers from `bloq.signature.lefts()` that concatenate to form it.
+        left_only: If False, the output registers will also follow `partition`.
+            Otherwise, the output registers will follow `bloq.signature.rights()`.
+            This flag must be set to True if `bloq` does not have the same LEFT and RIGHT registers,
+            as is required for the bloq to be fully wrapped on the left and right.
+
+    Registers:
+        [user_spec]: The output registers of the wrapped bloq.
+    """
+
+    bloq: Bloq
+    partitions: Sequence[Tuple[Register, Sequence[str]]] = field(
+        converter=lambda s: tuple((r, tuple(rs)) for r, rs in s)
+    )
+    left_only: bool = False
+
+    def __attrs_post_init__(self):
+        regs = {r.name for r in self.bloq.signature.lefts()}
+        assert len(regs) == len(self.bloq.signature)
+        assert regs == {r for _, rs in self.partitions for r in rs}
+
+    @cached_property
+    def signature(self) -> Signature:
+        if self.left_only:
+            return Signature(
+                chain(
+                    (evolve(r, side=Side.LEFT) for r, _ in self.partitions),
+                    (evolve(r, side=Side.RIGHT) for r in self.bloq.signature.rights()),
+                )
+            )
+        else:
+            return Signature(r for r, _ in self.partitions)
+
+    def pretty_name(self) -> str:
+        return self.bloq.pretty_name()
+
+    def build_composite_bloq(self, bb: BloqBuilder, **soqs: SoquetT) -> Dict[str, SoquetT]:
+        parts: Dict[str, Partition] = dict()
+        in_regs: Dict[str, SoquetT] = dict()
+        for out_reg, bloq_regs in self.partitions:
+            part = Partition(
+                out_reg.bitsize, regs=tuple(self.bloq.signature.get_left(r) for r in bloq_regs)
+            )
+            parts[out_reg.name] = part
+            in_regs |= bb.add_d(part, x=soqs[out_reg.name])
+        bloq_out_regs = bb.add_d(self.bloq, **in_regs)
+        if self.left_only:
+            return bloq_out_regs
+
+        out_regs = {}
+        for soq_name in soqs.keys():
+            out_regs[soq_name] = bb.add(
+                parts[soq_name].adjoint(),
+                **{reg.name: bloq_out_regs[reg.name] for reg in parts[soq_name].signature.rights()},
+            )
+        return out_regs
+
+
+@bloq_example
+def _auto_partition() -> AutoPartition:
+    from qualtran import Controlled, CtrlSpec
+    from qualtran.bloqs.basic_gates import Swap
+
+    bloq = Controlled(Swap(1), CtrlSpec())
+    auto_partition = AutoPartition(
+        bloq, [(Register('x', QAny(2)), ['ctrl', 'x']), (Register('y', QAny(1)), ['y'])]
+    )
+    return auto_partition
+
+
+_AUTO_PARTITION_DOC = BloqDocSpec(
+    bloq_cls=AutoPartition,
+    import_line="from qualtran.bloqs.bookkeeping import AutoPartition",
+    examples=[_auto_partition],
+)

--- a/qualtran/bloqs/bookkeeping/auto_partition_test.py
+++ b/qualtran/bloqs/bookkeeping/auto_partition_test.py
@@ -1,0 +1,136 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import subprocess
+
+import pytest
+from attrs import evolve
+
+from qualtran.bloqs.bookkeeping.auto_partition import _auto_partition, AutoPartition
+
+
+def test_auto_partition(bloq_autotester):
+    bloq_autotester(_auto_partition)
+
+
+def test_auto_partition_input():
+    from qualtran import QAny, QBit, Register, Side
+
+    bloq = _auto_partition()
+
+    assert tuple(bloq.signature.lefts()) == (
+        Register('x', dtype=QAny(2)),
+        Register('y', dtype=QAny(1)),
+    )
+
+    assert tuple(bloq.signature.rights()) == (
+        Register('x', dtype=QAny(2)),
+        Register('y', dtype=QAny(1)),
+    )
+
+    x, y = bloq.call_classically(x=0b11, y=0b0)
+    assert x == 0b10
+    assert y == 0b1
+
+    x, y = bloq.call_classically(x=0b01, y=0b0)
+    assert x == 0b01
+    assert y == 0b0
+
+    bloq = evolve(bloq, left_only=True)
+
+    assert tuple(bloq.signature.lefts()) == (
+        Register('x', dtype=QAny(2), side=Side.LEFT),
+        Register('y', dtype=QAny(1), side=Side.LEFT),
+    )
+
+    assert tuple(bloq.signature.rights()) == (
+        Register('ctrl', dtype=QBit(), side=Side.RIGHT),
+        Register('x', dtype=QBit(), side=Side.RIGHT),
+        Register('y', dtype=QBit(), side=Side.RIGHT),
+    )
+
+    ctrl, x, y = bloq.call_classically(x=0b11, y=0b0)
+    assert ctrl == 0b1
+    assert x == 0b0
+    assert y == 0b1
+
+    ctrl, x, y = bloq.call_classically(x=0b01, y=0b0)
+    assert ctrl == 0b0
+    assert x == 0b1
+    assert y == 0b0
+
+
+def test_auto_partition_valid():
+    from qualtran import Controlled, CtrlSpec, QAny, QUInt, Register
+    from qualtran.bloqs.basic_gates import Swap
+
+    with pytest.raises(AssertionError):
+        bloq = Controlled(Swap(3), CtrlSpec(qdtypes=QUInt(4), cvs=0b0110))
+        bloq = AutoPartition(
+            bloq, [(Register('a', QAny(3)), ['y']), (Register('b', QAny(3)), ['x'])]
+        )
+
+
+def test_auto_partition_big():
+    from qualtran import Controlled, CtrlSpec, QAny, QUInt, Register, Side
+    from qualtran.bloqs.basic_gates import Swap
+
+    bloq = Controlled(Swap(3), CtrlSpec(qdtypes=QUInt(4), cvs=0b0110))
+    bloq = AutoPartition(
+        bloq, [(Register('a', QAny(7)), ['y', 'ctrl']), (Register('b', QAny(3)), ['x'])]
+    )
+
+    assert tuple(bloq.signature.lefts()) == (
+        Register('a', dtype=QAny(7)),
+        Register('b', dtype=QAny(3)),
+    )
+
+    assert tuple(bloq.signature.rights()) == (
+        Register('a', dtype=QAny(7)),
+        Register('b', dtype=QAny(3)),
+    )
+
+    a, b = bloq.call_classically(a=0b1010110, b=0b010)
+    assert a == 0b0100110
+    assert b == 0b101
+
+    a, b = bloq.call_classically(a=0b1010111, b=0b010)
+    assert a == 0b1010111
+    assert b == 0b010
+
+    bloq = evolve(bloq, left_only=True)
+
+    assert tuple(bloq.signature.lefts()) == (
+        Register('a', dtype=QAny(7), side=Side.LEFT),
+        Register('b', dtype=QAny(3), side=Side.LEFT),
+    )
+
+    assert tuple(bloq.signature.rights()) == (
+        Register('ctrl', dtype=QUInt(4), side=Side.RIGHT),
+        Register('x', dtype=QAny(3), side=Side.RIGHT),
+        Register('y', dtype=QAny(3), side=Side.RIGHT),
+    )
+
+    ctrl, x, y = bloq.call_classically(a=0b1010110, b=0b010)
+    assert ctrl == 0b0110
+    assert x == 0b101
+    assert y == 0b010
+
+    ctrl, x, y = bloq.call_classically(a=0b1010111, b=0b010)
+    assert ctrl == 0b0111
+    assert x == 0b010
+    assert y == 0b101
+
+
+def test_no_circular_import():
+    subprocess.check_call(['python', '-c', 'from qualtran.bloqs.bookkeeping import auto_partition'])

--- a/qualtran/bloqs/bookkeeping/bookkeeping.ipynb
+++ b/qualtran/bloqs/bookkeeping/bookkeeping.ipynb
@@ -706,6 +706,260 @@
     "from qualtran.bloqs.for_testing import TestCastToFrom\n",
     "show_bloq(TestCastToFrom().decompose_bloq(), type='dtype')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6e0f882",
+   "metadata": {
+    "cq.autogen": "AutoPartition.bloq_doc.md"
+   },
+   "source": [
+    "## `AutoPartition`\n",
+    "Wrap a bloq with `Partition` to fit an alternative set of input and output registers\n",
+    "   such that splits / joins can be avoided in diagrams.\n",
+    "\n",
+    "#### Parameters\n",
+    " - `bloq`: The bloq to wrap.\n",
+    " - `partitions`: A sequence of pairs specifying each register that the wrapped bloq should accept and the names of registers from `bloq.signature.lefts()` that concatenate to form it.\n",
+    " - `left_only`: If False, the output registers will also follow `partition`. Otherwise, the output registers will follow `bloq.signature.rights()`. This flag must be set to True if `bloq` does not have the same LEFT and RIGHT registers, as is required for the bloq to be fully wrapped on the left and right. \n",
+    "\n",
+    "#### Registers\n",
+    " - `[user_spec]`: The output registers of the wrapped bloq.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c0a8e98",
+   "metadata": {
+    "cq.autogen": "AutoPartition.bloq_doc.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.bookkeeping import AutoPartition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77223022",
+   "metadata": {
+    "cq.autogen": "AutoPartition.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3759b4fa",
+   "metadata": {
+    "cq.autogen": "AutoPartition.auto_partition"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran import Controlled, CtrlSpec\n",
+    "from qualtran.bloqs.basic_gates import Swap\n",
+    "\n",
+    "bloq = Controlled(Swap(1), CtrlSpec())\n",
+    "auto_partition = AutoPartition(\n",
+    "    bloq, [(Register('x', QAny(2)), ['ctrl', 'x']), (Register('y', QAny(1)), ['y'])]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06481dca",
+   "metadata": {
+    "cq.autogen": "AutoPartition.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49cd2fe3",
+   "metadata": {
+    "cq.autogen": "AutoPartition.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([auto_partition],\n",
+    "           ['`auto_partition`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9735ebbc",
+   "metadata": {
+    "cq.autogen": "AutoPartition.call_graph.md"
+   },
+   "source": [
+    "### Call Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4ac66db",
+   "metadata": {
+    "cq.autogen": "AutoPartition.call_graph.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.resource_counting.generalizers import ignore_split_join\n",
+    "auto_partition_g, auto_partition_sigma = auto_partition.call_graph(max_depth=1, generalizer=ignore_split_join)\n",
+    "show_call_graph(auto_partition_g)\n",
+    "show_counts_sigma(auto_partition_sigma)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2e826",
+   "metadata": {},
+   "source": [
+    "### Using `AutoPartition` to simplify diagrams"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31946e00",
+   "metadata": {},
+   "source": [
+    "Sometimes, we want to use bloqs whose signatures don't quite match up with the signature of a bigger bloq we want to build. For example, the bloq might have a flat list of qubits whereas we have a big register, or vice versa. \n",
+    "\n",
+    "Normally, we can just split / join / partition during the decomposition and go on our way, but this leads to unsightly diagrams like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9737eea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from functools import cached_property\n",
+    "\n",
+    "from qualtran.bloqs.rotations.hamming_weight_phasing import HammingWeightPhasing\n",
+    "from qualtran.drawing import draw_musical_score\n",
+    "from qualtran.drawing.musical_score import get_musical_score_data\n",
+    "\n",
+    "\n",
+    "@attrs.frozen\n",
+    "class ManyBit(Bloq):\n",
+    "    @cached_property\n",
+    "    def signature(self) -> Signature:\n",
+    "        return Signature((Register('xs', QBit(), shape=(20,)),))\n",
+    "\n",
+    "\n",
+    "@attrs.frozen\n",
+    "class NotWrapped(Bloq):\n",
+    "    bitsize: int = 10\n",
+    "\n",
+    "    @cached_property\n",
+    "    def signature(self) -> Signature:\n",
+    "        return Signature((Register('x', QBit(), shape=(self.bitsize,)), Register('y', QAny(20))))\n",
+    "\n",
+    "    def build_composite_bloq(\n",
+    "        self, bb: BloqBuilder, x: 'SoquetT', y: 'SoquetT'\n",
+    "    ) -> Dict[str, 'SoquetT']:\n",
+    "        for i in range(5):\n",
+    "            two_bit = bb.join(x[i * 2 : i * 2 + 2], QUInt(2))\n",
+    "            two_bit = bb.add(HammingWeightPhasing(2, 0.11), x=two_bit)\n",
+    "            x[i * 2 : i * 2 + 2] = bb.split(two_bit)\n",
+    "        many_bit = bb.split(y)\n",
+    "        many_bit = bb.add(ManyBit(), xs=many_bit)\n",
+    "        return {'x': x, 'y': bb.join(many_bit)}\n",
+    "\n",
+    "\n",
+    "bloq = NotWrapped()\n",
+    "draw_musical_score(get_musical_score_data(bloq.decompose_bloq()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6bfd5c7",
+   "metadata": {},
+   "source": [
+    "Using the `AutoPartition` bloq, we can hide the partition/unpartition pairs behind a level of decomposition, thereby cleaning up the diagram:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72cfb27f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@attrs.frozen\n",
+    "class Wrapped(Bloq):\n",
+    "    bitsize: int = 10\n",
+    "\n",
+    "    @cached_property\n",
+    "    def signature(self) -> Signature:\n",
+    "        return Signature((Register('x', QBit(), shape=(self.bitsize,)), Register('y', QAny(20))))\n",
+    "\n",
+    "    def build_composite_bloq(\n",
+    "        self, bb: BloqBuilder, x: 'SoquetT', y: 'SoquetT'\n",
+    "    ) -> Dict[str, 'SoquetT']:\n",
+    "        for i in range(5):\n",
+    "            hwp = HammingWeightPhasing(2, i * 0.11)\n",
+    "            x[i * 2 : i * 2 + 2] = bb.add(\n",
+    "                AutoPartition(hwp, [(Register('reg_1', QBit(), shape=(2,)), ('x',))]),\n",
+    "                reg_1=x[i * 2 : i * 2 + 2],\n",
+    "            )\n",
+    "        many = ManyBit()\n",
+    "        b = AutoPartition(many, [(Register('y', QAny(20)), ('xs',))])\n",
+    "        y = bb.add(b, y=y)\n",
+    "        return {'x': x, 'y': y}\n",
+    "\n",
+    "\n",
+    "bloq = Wrapped()\n",
+    "draw_musical_score(get_musical_score_data(bloq.decompose_bloq()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "310a67d5",
+   "metadata": {},
+   "source": [
+    "Instead of explicitly instantiating a `AutoPartition`, we can also use the utility function `BloqBuilder.add_and_partition`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e3be77e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@attrs.frozen\n",
+    "class Wrapped(Bloq):\n",
+    "    bitsize: int = 10\n",
+    "\n",
+    "    @cached_property\n",
+    "    def signature(self) -> Signature:\n",
+    "        return Signature((Register('x', QBit(), shape=(self.bitsize,)), Register('y', QAny(20))))\n",
+    "\n",
+    "    def build_composite_bloq(\n",
+    "        self, bb: BloqBuilder, x: 'SoquetT', y: 'SoquetT'\n",
+    "    ) -> Dict[str, 'SoquetT']:\n",
+    "        for i in range(5):\n",
+    "            hwp = HammingWeightPhasing(2, i * 0.11)\n",
+    "            x[i * 2 : i * 2 + 2] = bb.add_and_partition(\n",
+    "                hwp, [(Register('reg_1', QBit(), shape=(2,)), ('x',))], reg_1=x[i * 2 : i * 2 + 2]\n",
+    "            )\n",
+    "        many = ManyBit()\n",
+    "        y = bb.add_and_partition(many, [(Register('y', QAny(20)), ('xs',))], y=y)\n",
+    "        return {'x': x, 'y': y}\n",
+    "\n",
+    "\n",
+    "bloq = Wrapped()\n",
+    "draw_musical_score(get_musical_score_data(bloq.decompose_bloq()))"
+   ]
   }
  ],
  "metadata": {

--- a/qualtran/conftest.py
+++ b/qualtran/conftest.py
@@ -92,6 +92,8 @@ def assert_bloq_example_serializes_for_pytest(bloq_ex: BloqExample):
         'symbolic_hamsim_by_gqsp',
         'gqsp_1d_ising',
         'auto_partition',
+        'unitary_block_encoding',
+        'tensor_product_block_encoding',
     ]:
         pytest.xfail("Skipping serialization test for bloq examples that cannot yet be serialized.")
 

--- a/qualtran/conftest.py
+++ b/qualtran/conftest.py
@@ -91,6 +91,7 @@ def assert_bloq_example_serializes_for_pytest(bloq_ex: BloqExample):
         'trott_unitary',
         'symbolic_hamsim_by_gqsp',
         'gqsp_1d_ising',
+        'auto_partition',
     ]:
         pytest.xfail("Skipping serialization test for bloq examples that cannot yet be serialized.")
 

--- a/qualtran/resource_counting/generalizers.py
+++ b/qualtran/resource_counting/generalizers.py
@@ -19,7 +19,7 @@ multiple bloqs whose attributes differ in ways that do not affect the cost estim
 into one, more general bloq. The functions in this module can be used as generalizers
 for this argument.
 """
-from typing import Optional
+from typing import Callable, Optional
 
 import attrs
 import sympy
@@ -31,12 +31,24 @@ PHI = sympy.Symbol(r'\phi')
 CV = sympy.Symbol("cv")
 
 
+def _ignore_wrapper(f: Callable[[Bloq], Optional[Bloq]], b: Bloq) -> Optional[Bloq]:
+    """Helper for generalizers to traverse wrapper bloqs."""
+    from qualtran.bloqs.bookkeeping import AutoPartition
+
+    if isinstance(b, AutoPartition):
+        bloq = f(b.bloq)
+        return None if bloq is None else attrs.evolve(b, bloq=bloq)
+    return b
+
+
 def ignore_split_join(b: Bloq) -> Optional[Bloq]:
     """A generalizer that ignores split and join operations."""
-    from qualtran.bloqs.bookkeeping import Cast, Join, Partition, Split
+    from qualtran.bloqs.bookkeeping import AutoPartition, Cast, Join, Partition, Split
 
     if isinstance(b, (Split, Join, Partition, Cast)):
         return None
+    if isinstance(b, AutoPartition):
+        return ignore_split_join(b.bloq)
     return b
 
 
@@ -46,7 +58,8 @@ def ignore_alloc_free(b: Bloq) -> Optional[Bloq]:
 
     if isinstance(b, (Allocate, Free)):
         return None
-    return b
+
+    return _ignore_wrapper(ignore_alloc_free, b)
 
 
 def generalize_rotation_angle(b: Bloq) -> Optional[Bloq]:
@@ -63,7 +76,7 @@ def generalize_rotation_angle(b: Bloq) -> Optional[Bloq]:
         # ignore `is_adjoint`.
         return attrs.evolve(b, is_adjoint=False)
 
-    return b
+    return _ignore_wrapper(generalize_rotation_angle, b)
 
 
 def generalize_cvs(b: Bloq) -> Optional[Bloq]:
@@ -75,7 +88,7 @@ def generalize_cvs(b: Bloq) -> Optional[Bloq]:
     if isinstance(b, MultiAnd):
         return attrs.evolve(b, cvs=HasLength(b.n_ctrls))
 
-    return b
+    return _ignore_wrapper(generalize_cvs, b)
 
 
 def ignore_cliffords(b: Bloq) -> Optional[Bloq]:
@@ -84,7 +97,7 @@ def ignore_cliffords(b: Bloq) -> Optional[Bloq]:
 
     if bloq_is_clifford(b):
         return None
-    return b
+    return _ignore_wrapper(ignore_cliffords, b)
 
 
 def cirq_to_bloqs(b: Bloq) -> Optional[Bloq]:
@@ -93,6 +106,6 @@ def cirq_to_bloqs(b: Bloq) -> Optional[Bloq]:
     from qualtran.cirq_interop._cirq_to_bloq import _cirq_gate_to_bloq
 
     if not isinstance(b, CirqGateAsBloq):
-        return b
+        return _ignore_wrapper(cirq_to_bloqs, b)
 
     return _cirq_gate_to_bloq(b.gate)

--- a/qualtran/resource_counting/generalizers_test.py
+++ b/qualtran/resource_counting/generalizers_test.py
@@ -15,7 +15,7 @@ import cirq
 
 from qualtran import Adjoint, QAny, Register
 from qualtran.bloqs.basic_gates import CNOT, Rx, TwoBitSwap
-from qualtran.bloqs.bookkeeping import Allocate, Free, Join, Partition, Split
+from qualtran.bloqs.bookkeeping import Allocate, AutoPartition, Free, Join, Partition, Split
 from qualtran.bloqs.mcmt.and_bloq import And, MultiAnd
 from qualtran.cirq_interop import CirqGateAsBloq
 from qualtran.resource_counting._generalization import _make_composite_generalizer
@@ -44,6 +44,10 @@ _BLOQS_TO_FILTER = [
     Adjoint(TwoBitSwap()),
     Partition(5, (Register('x', QAny(2)), Register('y', QAny(3)))),
     CirqGateAsBloq(cirq.S),
+    AutoPartition(
+        AutoPartition(Rx(0.123), [(Register('q', QAny(1)), ['q'])]),
+        [(Register('q', QAny(1)), ['q'])],
+    ),
 ]
 
 
@@ -63,6 +67,7 @@ def test_ignore_split_join():
         Adjoint(TwoBitSwap()),
         None,  # Partition(5, (Register('x', QAny(2)), Register('y', QAny(3))))
         CirqGateAsBloq(cirq.S),
+        Rx(0.123),
     ]
 
 
@@ -82,6 +87,10 @@ def test_ignore_alloc_free():
         Adjoint(TwoBitSwap()),
         Partition(5, (Register('x', QAny(2)), Register('y', QAny(3)))),
         CirqGateAsBloq(cirq.S),
+        AutoPartition(
+            AutoPartition(Rx(0.123), [(Register('q', QAny(1)), ['q'])]),
+            [(Register('q', QAny(1)), ['q'])],
+        ),
     ]
 
 
@@ -101,6 +110,10 @@ def test_generalize_rotation_angle():
         Adjoint(TwoBitSwap()),
         Partition(5, (Register('x', QAny(2)), Register('y', QAny(3)))),
         CirqGateAsBloq(cirq.S),
+        AutoPartition(
+            AutoPartition(Rx(PHI), [(Register('q', QAny(1)), ['q'])]),
+            [(Register('q', QAny(1)), ['q'])],
+        ),
     ]
 
 
@@ -120,6 +133,10 @@ def test_generalize_cvs():
         Adjoint(TwoBitSwap()),
         Partition(5, (Register('x', QAny(2)), Register('y', QAny(3)))),
         CirqGateAsBloq(cirq.S),
+        AutoPartition(
+            AutoPartition(Rx(0.123), [(Register('q', QAny(1)), ['q'])]),
+            [(Register('q', QAny(1)), ['q'])],
+        ),
     ]
 
 
@@ -139,6 +156,10 @@ def test_ignore_cliffords():
         None,  # Adjoint(TwoBitSwap()),
         Partition(5, (Register('x', QAny(2)), Register('y', QAny(3)))),
         CirqGateAsBloq(cirq.S),
+        AutoPartition(
+            AutoPartition(Rx(0.123), [(Register('q', QAny(1)), ['q'])]),
+            [(Register('q', QAny(1)), ['q'])],
+        ),
     ]
 
 
@@ -159,6 +180,10 @@ def test_ignore_cliffords_with_cirq():
         None,  # Adjoint(TwoBitSwap()),
         Partition(5, (Register('x', QAny(2)), Register('y', QAny(3)))),
         None,  # cirq.S,
+        AutoPartition(
+            AutoPartition(Rx(0.123), [(Register('q', QAny(1)), ['q'])]),
+            [(Register('q', QAny(1)), ['q'])],
+        ),
     ]
 
 
@@ -187,4 +212,5 @@ def test_many_generalizers():
         # Adjoint(TwoBitSwap()),
         # Partition(5, (Register('x', QAny(2)), Register('y', QAny(3))))
         # cirq.S,
+        Rx(PHI),
     ]

--- a/qualtran/serialization/resolver_dict.py
+++ b/qualtran/serialization/resolver_dict.py
@@ -34,6 +34,8 @@ import qualtran.bloqs.basic_gates.y_gate
 import qualtran.bloqs.basic_gates.z_basis
 import qualtran.bloqs.block_encoding
 import qualtran.bloqs.block_encoding.lcu_select_and_prepare
+import qualtran.bloqs.block_encoding.tensor_product
+import qualtran.bloqs.block_encoding.unitary
 import qualtran.bloqs.bookkeeping
 import qualtran.bloqs.chemistry.black_boxes
 import qualtran.bloqs.chemistry.df.double_factorization
@@ -188,6 +190,8 @@ RESOLVER_DICT = {
     "qualtran.bloqs.block_encoding.lcu_block_encoding.BlackBoxPrepare": qualtran.bloqs.block_encoding.lcu_block_encoding.BlackBoxPrepare,
     "qualtran.bloqs.block_encoding.lcu_block_encoding.BlackBoxSelect": qualtran.bloqs.block_encoding.lcu_block_encoding.BlackBoxSelect,
     "qualtran.bloqs.block_encoding.chebyshev_polynomial.ChebyshevPolynomial": qualtran.bloqs.block_encoding.chebyshev_polynomial.ChebyshevPolynomial,
+    "qualtran.bloqs.block_encoding.unitary.Unitary": qualtran.bloqs.block_encoding.unitary.Unitary,
+    "qualtran.bloqs.block_encoding.tensor_product.TensorProduct": qualtran.bloqs.block_encoding.tensor_product.TensorProduct,
     "qualtran.bloqs.bookkeeping.allocate.Allocate": qualtran.bloqs.bookkeeping.allocate.Allocate,
     "qualtran.bloqs.bookkeeping.arbitrary_clifford.ArbitraryClifford": qualtran.bloqs.bookkeeping.arbitrary_clifford.ArbitraryClifford,
     "qualtran.bloqs.bookkeeping.auto_partition.AutoPartition": qualtran.bloqs.bookkeeping.auto_partition.AutoPartition,

--- a/qualtran/serialization/resolver_dict.py
+++ b/qualtran/serialization/resolver_dict.py
@@ -190,6 +190,7 @@ RESOLVER_DICT = {
     "qualtran.bloqs.block_encoding.chebyshev_polynomial.ChebyshevPolynomial": qualtran.bloqs.block_encoding.chebyshev_polynomial.ChebyshevPolynomial,
     "qualtran.bloqs.bookkeeping.allocate.Allocate": qualtran.bloqs.bookkeeping.allocate.Allocate,
     "qualtran.bloqs.bookkeeping.arbitrary_clifford.ArbitraryClifford": qualtran.bloqs.bookkeeping.arbitrary_clifford.ArbitraryClifford,
+    "qualtran.bloqs.bookkeeping.auto_partition.AutoPartition": qualtran.bloqs.bookkeeping.auto_partition.AutoPartition,
     "qualtran.bloqs.bookkeeping.cast.Cast": qualtran.bloqs.bookkeeping.cast.Cast,
     "qualtran.bloqs.bookkeeping.free.Free": qualtran.bloqs.bookkeeping.free.Free,
     "qualtran.bloqs.bookkeeping.join.Join": qualtran.bloqs.bookkeeping.join.Join,


### PR DESCRIPTION
Depends on #1086.

Add instances of `BlockEncoding` that implement 1) a trivial block encoding of a unitary operator and 2) a tensor product of block encodings.

Extend the `BlockEncoding` interface to expose the properties `alpha`, `num_ancillas`, and `epsilon` of block encodings.

Permit `Signatures` to include registers of zero bits, i.e. `QAny(0)`. This is necessary to support a uniform interface of block encodings that may or may not use ancilla qubits but should always expose a register named `ancilla`.

With the newly designed block encoding interface, the `selection_registers`, `junk_registers`, and `target_registers` methods should now be considered deprecated and will be removed in a future PR.